### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM alpine:3.10
 
-ARG version=2.2.0-stable
-
 RUN apk add ca-certificates wget unzip libc6-compat \
-    && wget https://downloads.hak5.org/api/devices/cloudc2-community/firmwares/${version} --no-cache \ 
-    && unzip ${version} \
+    && wget https://downloads.hak5.org/api/devices/cloudc2/firmwares/latest --no-cache \ 
+    && unzip latest \
     && mkdir /app \
     && mv c2_community-linux-64 /app \
     && rm c2* ${version} \


### PR DESCRIPTION
Updated dockerfile to use direct url to latest cloudc2 download rather than using a version: https://downloads.hak5.org/api/devices/cloudc2/firmwares/latest